### PR TITLE
MT76 Driver Support for ra* device instances.

### DIFF
--- a/belaUI.js
+++ b/belaUI.js
@@ -305,21 +305,13 @@ function updateNetif() {
         if (inetAddr) inetAddr = inetAddr[1];
 
         // update the list of WiFi devices
-        if (name && name.match('^wlan')) {
+        if (name && name.match('^(wlan|ra)')) {
           let hwAddr = int.match(/ether ([0-9a-f:]+)/);
           if (hwAddr) {
             wiFiDeviceListAdd(name, hwAddr[1], inetAddr);
           }
         }
-        // Adding support for MediaTek MT67 devices:
-        // Linksys AE6000
-        if (name && name.match('^ra')) {
-          let hwAddr = int.match(/ether ([0-9a-f:]+)/);
-          if (hwAddr) {
-            wiFiDeviceListAdd(name, hwAddr[1], inetAddr);
-          }
-        }
-
+        
         if (name == 'lo' || name.match('^docker') || name.match('^l4tbr')) continue;
 
         if (!inetAddr) continue;

--- a/belaUI.js
+++ b/belaUI.js
@@ -311,6 +311,14 @@ function updateNetif() {
             wiFiDeviceListAdd(name, hwAddr[1], inetAddr);
           }
         }
+        // Adding support for MediaTek MT67 devices:
+        // Linksys AE6000
+        if (name && name.match('^ra')) {
+          let hwAddr = int.match(/ether ([0-9a-f:]+)/);
+          if (hwAddr) {
+            wiFiDeviceListAdd(name, hwAddr[1], inetAddr);
+          }
+        }
 
         if (name == 'lo' || name.match('^docker') || name.match('^l4tbr')) continue;
 


### PR DESCRIPTION
Adding Support to the Belabox UI for the MT76 Driver, used in the Linksys AE6000.

This Driver DKMS is pretty stable on Ubuntu 18.04 on the Jetson Nano, and allows for multiple instances of the same card to be on the device. I've switched over to using these usb dongles instead of the more popular `rtl` based ones.

The problem is: It uses a different Network Device id: `ra*`

To get around this, I simply added a separate match in `belaUI.js` for `ra`, which does allow it to be controlled via `belaUI`.

I'd like to also know where I can push code to add the dkms to the image build and the updates to the network manager to control it. 